### PR TITLE
Make generateState protected

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -295,7 +295,7 @@ export class OAuth2Strategy<
     return url;
   }
 
-  private generateState() {
+  protected generateState() {
     return uuid();
   }
 


### PR DESCRIPTION
### Reason for PR
As state is the most logical way for AWS cognito (https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html) and suppose also other Oauth2 clients for passing on some parameters between request for authorization and redirect after authorization.

It would be handy for being able to adjust this value if needed/wanted.

In our case we used it for passing on a redirectTo url to our callback page 