### PR TITLE
Allowing response_type to be set as a option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export class OAuth2Strategy<
   protected clientID: string;
   protected clientSecret: string;
   protected callbackURL: string;
-  protected responseType: string;
+  protected responseType: "id_token" | "token" | "id_token token" | "code" | "code id_token" | "code id_token token";
 
   private sessionStateKey = "oauth2:state";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export interface OAuth2StrategyOptions {
   clientID: string;
   clientSecret: string;
   callbackURL: string;
-  responseType?: string;
+  responseType?: "id_token" | "token" | "id_token token" | "code" | "code id_token" | "code id_token token";
 }
 
 export interface OAuth2StrategyVerifyParams<

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export interface OAuth2StrategyOptions {
   clientID: string;
   clientSecret: string;
   callbackURL: string;
+  responseType: string;
 }
 
 export interface OAuth2StrategyVerifyParams<
@@ -103,6 +104,7 @@ export class OAuth2Strategy<
   protected clientID: string;
   protected clientSecret: string;
   protected callbackURL: string;
+  protected responseType: string;
 
   private sessionStateKey = "oauth2:state";
 
@@ -119,6 +121,7 @@ export class OAuth2Strategy<
     this.clientID = options.clientID;
     this.clientSecret = options.clientSecret;
     this.callbackURL = options.callbackURL;
+    this.responseType = options.responseType;
   }
 
   async authenticate(
@@ -281,7 +284,7 @@ export class OAuth2Strategy<
     let params = new URLSearchParams(
       this.authorizationParams(new URL(request.url).searchParams)
     );
-    params.set("response_type", "code");
+    params.set("response_type", this.responseType);
     params.set("client_id", this.clientID);
     params.set(
       "redirect_uri",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export interface OAuth2StrategyOptions {
   clientID: string;
   clientSecret: string;
   callbackURL: string;
-  responseType: string;
+  responseType?: string;
 }
 
 export interface OAuth2StrategyVerifyParams<
@@ -121,7 +121,7 @@ export class OAuth2Strategy<
     this.clientID = options.clientID;
     this.clientSecret = options.clientSecret;
     this.callbackURL = options.callbackURL;
-    this.responseType = options.responseType;
+    this.responseType = options.responseType ?? "code";
   }
 
   async authenticate(


### PR DESCRIPTION
There are many response types which can be used for OAuth2. Instead of hardcoding `response_type: 'code'`, this allows the package user to set their response type.