### PR TITLE
add type number to id in OAuth2Profile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ let debug = createDebug("OAuth2Strategy");
 
 export interface OAuth2Profile {
   provider: string;
-  id?: string;
+  id?: string | number;
   displayName?: string;
   name?: {
     familyName?: string;


### PR DESCRIPTION
Some providers like Strava return the id as an integer. This change would allow oauth2 strategies bases on this strategy to use the correct type without converting the id to a number before returning the profile in `userProfile()`