### PR TITLE
Allow Basic authentication header

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ authenticator.use(
       clientID: process.env.CLIENT_ID,
       clientSecret: process.env.CLIENT_SECRET,
       callbackURL: "https://example.app/auth/callback",
+      useBasicAuthenticationHeader: false // defaults to false
     },
     async ({ accessToken, refreshToken, extraParams, profile, context }) => {
       // here you can use the params above to get the user and return it

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export interface OAuth2StrategyOptions {
   clientSecret: string;
   callbackURL: string;
   responseType?: ResponseType;
+  useBasicAuthenticationHeader?: boolean;
 }
 
 export interface OAuth2StrategyVerifyParams<
@@ -113,6 +114,7 @@ export class OAuth2Strategy<
   protected clientSecret: string;
   protected callbackURL: string;
   protected responseType: ResponseType;
+  protected useBasicAuthenticationHeader: boolean;
 
   private sessionStateKey = "oauth2:state";
 
@@ -130,6 +132,8 @@ export class OAuth2Strategy<
     this.clientSecret = options.clientSecret;
     this.callbackURL = options.callbackURL;
     this.responseType = options.responseType ?? "code";
+    this.useBasicAuthenticationHeader =
+      options.useBasicAuthenticationHeader ?? false;
   }
 
   async authenticate(
@@ -321,8 +325,23 @@ export class OAuth2Strategy<
     refreshToken: string;
     extraParams: ExtraParams;
   }> {
-    params.set("client_id", this.clientID);
-    params.set("client_secret", this.clientSecret);
+    let headers: HeadersInit = {
+      "Content-Type": "application/x-www-form-urlencoded",
+    };
+
+    if (this.useBasicAuthenticationHeader) {
+      const b64EncodedCredentials = Buffer.from(
+        `${this.clientID}:${this.clientSecret}`
+      ).toString("base64");
+
+      headers = {
+        ...headers,
+        Authorization: `Basic ${b64EncodedCredentials}`,
+      };
+    } else {
+      params.set("client_id", this.clientID);
+      params.set("client_secret", this.clientSecret);
+    }
 
     if (params.get("grant_type") === "refresh_token") {
       params.set("refresh_token", code);
@@ -332,7 +351,7 @@ export class OAuth2Strategy<
 
     let response = await fetch(this.tokenURL, {
       method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      headers,
       body: params,
     });
 


### PR DESCRIPTION
This adds a flag to use a Basic authentication header instead of setting the `client_id` and `client_secret` params in the body of the request.

This resolves Issue #35 .