### PR TITLE
Make `fetchAccessToken` protected instead of private

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -369,7 +369,7 @@ export class OAuth2Strategy<
   /**
    * Format the data to be sent in the request body to the token endpoint.
    */
-  private async fetchAccessToken(
+  protected async fetchAccessToken(
     code: string,
     params: URLSearchParams
   ): Promise<{


### PR DESCRIPTION
Closes #48 

This will make it much easier to implement refresh tokens and rotation using a derived strategy. This is possible currently just by using `@ts-ignore` or `@ts-expect-error` but it would be nice to have the approach supported by the types as well.