### PR TITLE
Add homepage and repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.8.0",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
+  "homepage": "https://github.com/sergiodxa/remix-auth-oauth2#readme",
+  "repository": {
+    "url": "https://github.com/sergiodxa/remix-auth-oauth2",
+    "type": "git"
+  },
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc --project tsconfig.json",


### PR DESCRIPTION
Hi 🙂👋, 

I think it would be nice to add the `homepage` and `repository` fields to the `package.json`.

Upon publishing this should make it easier to discover the related pages on GitHub from pages such as https://www.npmjs.com/package/remix-auth-oauth2.

For example compare it with https://www.npmjs.com/package/remix-auth, which has repository and homepage links.