### PR TITLE
chore: remove uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
-        "remix-auth": "^3.4.0",
-        "uuid": "^8.3.2"
+        "remix-auth": "^3.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.17.10",
@@ -9412,6 +9411,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -16567,7 +16567,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "remix-auth": "^3.4.0",
-    "uuid": "^8.3.2"
+    "remix-auth": "^3.4.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   Strategy,
   StrategyVerifyCallback,
 } from "remix-auth";
-import { v4 as uuid } from "uuid";
+import { randomUUID } from "node:crypto";
 
 let debug = createDebug("OAuth2Strategy");
 
@@ -369,7 +369,7 @@ export class OAuth2Strategy<
   }
 
   private generateState() {
-    return uuid();
+    return randomUUID();
   }
 
   /**


### PR DESCRIPTION
not sure if you have a specific node version you want to support, but getting a `uuid` can be done from the node standard library now.