### PR TITLE
Add configuration option for scope attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ authenticator.use(
       clientID: process.env.CLIENT_ID,
       clientSecret: process.env.CLIENT_SECRET,
       callbackURL: "https://example.app/auth/callback",
-      useBasicAuthenticationHeader: false, // defaults to false
+      scope: "openid email profile", // optional
+      useBasicAuthenticationHeader: false // defaults to false
     },
     async ({
       accessToken,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export interface OAuth2StrategyOptions {
   clientID: string;
   clientSecret: string;
   callbackURL: string;
+  scope?: string;
   responseType?: ResponseType;
   useBasicAuthenticationHeader?: boolean;
 }
@@ -115,6 +116,7 @@ export class OAuth2Strategy<
   protected callbackURL: string;
   protected responseType: ResponseType;
   protected useBasicAuthenticationHeader: boolean;
+  protected scope?: string;
 
   private sessionStateKey = "oauth2:state";
 
@@ -131,6 +133,7 @@ export class OAuth2Strategy<
     this.clientID = options.clientID;
     this.clientSecret = options.clientSecret;
     this.callbackURL = options.callbackURL;
+    this.scope = options.scope;
     this.responseType = options.responseType ?? "code";
     this.useBasicAuthenticationHeader =
       options.useBasicAuthenticationHeader ?? false;
@@ -361,6 +364,9 @@ export class OAuth2Strategy<
     params.set("client_id", this.clientID);
     params.set("redirect_uri", this.getCallbackURL(request).toString());
     params.set("state", state);
+    if (this.scope) {
+      params.set("scope", this.scope);
+    }
 
     let url = new URL(this.authorizationURL);
     url.search = params.toString();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -113,10 +113,28 @@ describe(OAuth2Strategy, () => {
         options.callbackURL
       );
       expect(redirect.searchParams.has("state")).toBeTruthy();
+      expect(redirect.searchParams.get("scope")).toBeNull();
 
       expect(session.get("oauth2:state")).toBe(
         redirect.searchParams.get("state")
       );
+    }
+  });
+
+  test("should build scope into authorization redirect when provided", async () => {
+    let strategy = new OAuth2Strategy<User, TestProfile>(
+      { ...options, scope: "scope_1 SCOPE2 scOpE3" },
+      verify
+    );
+
+    let request = new Request("https://example.com/login");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, BASE_OPTIONS);
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let redirect = new URL(error.headers.get("Location") as string);
+      expect(redirect.searchParams.get("scope")).toBe("scope_1 SCOPE2 scOpE3");
     }
   });
 


### PR DESCRIPTION
Resolves #50 #49 #51 

Based on fork found in #51 with a stray `.` removed and basic tests added

```
> npm run test

> remix-auth-oauth2@1.9.0 test
> jest --config=config/jest.config.ts --passWithNoTests

 PASS  test/index.test.ts
                                                                                                                                                                                                                                                                  
Test Suites: 1 passed, 1 total                                                                                                                                                                                                                                    
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        1.007 s
Ran all test suites.
```