### PR TITLE
Allow `state` to be set in `authorizationParams`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -363,7 +363,10 @@ export class OAuth2Strategy<
     params.set("response_type", this.responseType);
     params.set("client_id", this.clientID);
     params.set("redirect_uri", this.getCallbackURL(request).toString());
-    params.set("state", state);
+    // If "state" is provided in `authorizationParams`, it will be used instead of the generated one
+    if (!params.has("state")) {
+      params.set("state", state);
+    }
     // We need to check if `authorizationParams` has not set scopes to avoid regressions on dependent libraries
     if (!params.has("scope") && this.scope) {
       params.set("scope", this.scope);


### PR DESCRIPTION
As it stands, the `state` authorization param is controlled by a private method `generateState`, and you can't override it.

In my case, I'd like to be able to control this param and set it from the `authorizationParams` override. This PR allows for a check to happen in the `getAuthorizationURL` method. Please let me know your thoughts, as I'm no OAuth expert. 🙏 