### PR TITLE
Add missing `:` in getCallbackURL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -353,7 +353,7 @@ export class OAuth2Strategy<
     if (this.callbackURL.startsWith("/")) {
       return new URL(this.callbackURL, `${protocol}://${host}`);
     }
-    return new URL(`${protocol}//${this.callbackURL}`);
+    return new URL(`${protocol}://${this.callbackURL}`);
   }
 
   private getAuthorizationURL(request: Request, state: string) {


### PR DESCRIPTION
Looks like a small typo in a rarely hit code branch