### PR TITLE
Pass request to authorizationParams to support additional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,16 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
   // URLSearchParams with custom params we want to send to the authorizationURL.
   // Here we add the scope so Auth0 can use it, you can pass any extra param
   // you need to send to the authorizationURL here base on your provider.
-  protected authorizationParams(params: URLSearchParams): URLSearchParams {
+  // The `requestParams` argument represents additional URL search parameters
+  // that you may want to include in the authorization request. These are parameters
+  // that you might want to send based on specific conditions or user input,
+  // such as 'screen_hint'.
+  protected authorizationParams(
+    params: URLSearchParams,
+    requestParams?: URLSearchParams,
+  ): URLSearchParams {
     if (this.audience) params.set("audience", this.audience);
+    if (requestParams.get('example')) params.set('example', 'example');
     return params;
   }
 

--- a/README.md
+++ b/README.md
@@ -242,16 +242,17 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
   // URLSearchParams with custom params we want to send to the authorizationURL.
   // Here we add the scope so Auth0 can use it, you can pass any extra param
   // you need to send to the authorizationURL here base on your provider.
-  // The `requestParams` argument represents additional URL search parameters
-  // that you may want to include in the authorization request. These are parameters
-  // that you might want to send based on specific conditions or user input,
-  // such as 'screen_hint'.
+  // The `request` argument represents the entire Request object, allowing you
+  // to access various aspects of the incoming request, such as URL search parameters,
+  // headers, or other request-specific data. This flexibility enables you to
+  // dynamically set additional URL search parameters based on specific conditions
+  // or user input. For example, you might want to include a 'screen_hint' parameter.
   protected authorizationParams(
     params: URLSearchParams,
-    requestParams?: URLSearchParams,
+    request?: Request,
   ): URLSearchParams {
     if (this.audience) params.set("audience", this.audience);
-    if (requestParams.get('example')) params.set('example', 'example');
+    if (new URL(request.url).searchParams.get('example')) params.set('example', 'example');
     return params;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,7 @@ export class OAuth2Strategy<
 			// Extend authorization URL with extra non-standard params
 			authorizationURL.search = this.authorizationParams(
 				authorizationURL.searchParams,
+				url.searchParams,
 			).toString();
 
 			debug("Authorization URL", authorizationURL.toString());
@@ -346,7 +347,10 @@ export class OAuth2Strategy<
 	 * strategies can override this function in order to populate these
 	 * parameters as required by the provider.
 	 */
-	protected authorizationParams(params: URLSearchParams): URLSearchParams {
+	protected authorizationParams(
+		params: URLSearchParams,
+		requestParams?: URLSearchParams,
+	): URLSearchParams {
 		return new URLSearchParams(params);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,7 @@ export class OAuth2Strategy<
 			// Extend authorization URL with extra non-standard params
 			authorizationURL.search = this.authorizationParams(
 				authorizationURL.searchParams,
-				url.searchParams,
+				request,
 			).toString();
 
 			debug("Authorization URL", authorizationURL.toString());
@@ -349,7 +349,7 @@ export class OAuth2Strategy<
 	 */
 	protected authorizationParams(
 		params: URLSearchParams,
-		requestParams?: URLSearchParams,
+		request?: Request,
 	): URLSearchParams {
 		return new URLSearchParams(params);
 	}


### PR DESCRIPTION
**Summary:**

This pull request introduces an update to the `authorizationParams` method in the `OAuth2Strategy` class. The changes allow additional URL search parameters to be included in the authorization request. This update is reflected in both the code and the documentation.

**Issue Addressed:**

This update addresses a regression issue in the `authorizationParams` method. Previously, the code for handling request parameters was:

```ts
let params = new URLSearchParams(
  this.authorizationParams(new URL(request.url).searchParams),
);
```

In this implementation, the method effectively integrated both default and request-specific parameters. The regression occurred when the `authorizationParams` method was updated and no longer received request-specific parameters. This change disrupted the integration of these parameters into the final authorization URL, impacting the OAuth2 authentication flow.

**Updated Implementation:**

The updated `authorizationParams` method now accepts an additional `requestParams` parameter to handle request-specific parameters alongside default parameters:

```ts
protected authorizationParams(
  params: URLSearchParams,
  requestParams?: URLSearchParams,
): URLSearchParams {
  if (this.audience) params.set("audience", this.audience);
  if (requestParams?.get('screen_hint')) params.set('screen_hint', 'signup');
  return params;
}
```

In this example, `params` represent the default parameters, and `requestParams` include additional parameters like `'screen_hint'` based on specific requirements.

closes #104