### PR TITLE
Suggestion: use Buffer for base64 encoding over @oslojs/encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 	},
 	"dependencies": {
 		"@oslojs/crypto": "^0.6.2",
-		"@oslojs/encoding": "^0.4.1",
 		"@oslojs/oauth2": "^0.5.0",
 		"debug": "^4.3.4"
 	},

--- a/src/lib/authorization-code.ts
+++ b/src/lib/authorization-code.ts
@@ -5,7 +5,6 @@
  * old code and adapt it to the new structure of the library.
  */
 import { sha256 } from "@oslojs/crypto/sha2";
-import { encodeBase64urlNoPadding } from "@oslojs/encoding";
 
 export namespace AuthorizationCode {
 	export class AuthorizationURL extends URL {
@@ -35,7 +34,8 @@ export namespace AuthorizationCode {
 
 		public setS256CodeChallenge(codeVerifier: string): void {
 			const codeChallengeBytes = sha256(new TextEncoder().encode(codeVerifier));
-			const codeChallenge = encodeBase64urlNoPadding(codeChallengeBytes);
+			const codeChallenge =
+				Buffer.from(codeChallengeBytes).toString("base64url");
 			this.searchParams.set("code_challenge", codeChallenge);
 			this.searchParams.set("code_challenge_method", "S256");
 		}

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -4,18 +4,17 @@
  * direction of the library to focus on response parsing, I decided to copy the
  * old code and adapt it to the new structure of the library.
  */
-import { encodeBase64urlNoPadding } from "@oslojs/encoding";
 
 export namespace Generator {
 	export function codeVerifier(): string {
 		const randomValues = new Uint8Array(32);
 		crypto.getRandomValues(randomValues);
-		return encodeBase64urlNoPadding(randomValues);
+		return Buffer.from(randomValues).toString("base64url");
 	}
 
 	export function state(): string {
 		const randomValues = new Uint8Array(32);
 		crypto.getRandomValues(randomValues);
-		return encodeBase64urlNoPadding(randomValues);
+		return Buffer.from(randomValues).toString("base64url");
 	}
 }

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -4,7 +4,6 @@
  * direction of the library to focus on response parsing, I decided to copy the
  * old code and adapt it to the new structure of the library.
  */
-import { encodeBase64 } from "@oslojs/encoding";
 
 export namespace OAuth2Request {
 	export abstract class Context {
@@ -35,9 +34,9 @@ export namespace OAuth2Request {
 			clientId: string,
 			clientSecret: string,
 		): void {
-			const authorizationHeader = `Basic ${encodeBase64(
+			const authorizationHeader = `Basic ${Buffer.from(
 				new TextEncoder().encode(`${clientId}:${clientSecret}`),
-			)}`;
+			).toString("base64")}`;
 			this.headers.set("Authorization", authorizationHeader);
 		}
 


### PR DESCRIPTION
As noted in [this discussion](https://github.com/sergiodxa/remix-auth-oauth2/pull/108#discussion_r1705110405) it seems possible to drop the dependency on `@oslojs/encoding` in favour of using Buffer for encoding tasks.

A question would be whether a dependency on `Buffer` is acceptable for this project.