### PR TITLE
Correctly parse optional token response fields scope and refresh_token

### DIFF
--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -78,8 +78,8 @@ export namespace Token {
 					access_token: this.accessToken(),
 					token_type: this.tokenType(),
 					expires_in: this.accessTokenExpiresInSeconds(),
-					scope: this.scopes().join(" "),
-					refresh_token: this.refreshToken(),
+					...(this.hasScopes() && { scope: this.scopes().join(" ") }),
+					...(this.hasRefreshToken() && { refresh_token: this.refreshToken() }),
 				} as Response.Body & ExtraParams;
 			}
 		}


### PR DESCRIPTION
Summary:
This pull request makes an update to the parsing of the optional oauth2 token response fields: scope and refresh_token. If either or both of these fields are absent on the response from the token endpoint, a error is no longer thrown and instead the absent fields are absent on the returned JSON object.

Reference issue:
https://github.com/sergiodxa/remix-auth-oauth2/issues/111