### PR TITLE
Consider expires_in as optional

### DIFF
--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -77,7 +77,7 @@ export namespace Token {
 					...this.body,
 					access_token: this.accessToken(),
 					token_type: this.tokenType(),
-					expires_in: this.accessTokenExpiresInSeconds(),
+					...("expires_in" in this.body && { expires_in: this.accessTokenExpiresInSeconds() }),
 					...(this.hasScopes() && { scope: this.scopes().join(" ") }),
 					...(this.hasRefreshToken() && { refresh_token: this.refreshToken() }),
 				} as Response.Body & ExtraParams;


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc6749#section-5.1 the expires_in field is `RECOMMENDED` thus optional.

Providers like github and instagram do not set this field in the token response.

Related to  #112