### PR TITLE
Inlcude import in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ import type { StrategyVerifyCallback } from "remix-auth";
 // We need to import the OAuth2Strategy, the verify params and the profile interfaces
 import type {
   OAuth2Profile,
+  OAuth2StrategyOptions,
   OAuth2StrategyVerifyParams,
   TokenResponseBody,
 } from "remix-auth-oauth2";


### PR DESCRIPTION
The example in the README.md file was missing the import for the `OAuth2StrategyOptions` interface.