### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ export let authenticator = new Authenticator<User>(sessionStorage);
 authenticator.use(
   new OAuth2Strategy<
     User,
-    { providers: "provider-name" },
+    { provider: "provider-name" },
     { id_token: string }
   >(
     {


### PR DESCRIPTION
Current example causes the type error below:
```
Type '{ providers: "provider-name"; }' does not satisfy the constraint 'OAuth2Profile'.
  Property 'provider' is missing in type '{ providers: "provider-name"; }' but required in type 'OAuth2Profile'.
```