### PR TITLE
Add option to allow expected empty token revocation responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,11 @@ export interface OAuth2StrategyOptions {
 	tokenRevocationEndpoint?: URLConstructor;
 
 	/**
+	 * Indicates whether the token revocation response is expected to be empty.
+	 */
+	expectEmptyTokenRevocationResponse?: boolean;
+
+	/**
 	 * The scopes you want to request from the Identity Provider, this is a list
 	 * of strings that represent the permissions you want to request from the
 	 * user.
@@ -413,7 +418,10 @@ export class OAuth2Strategy<
 		await Token.RevocationRequest.send(
 			this.options.tokenRevocationEndpoint,
 			context,
-			{ signal: options.signal },
+			{
+				signal: options.signal,
+				expectEmptyResponse: this.options.expectEmptyTokenRevocationResponse,
+			},
 		);
 	}
 }

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -110,10 +110,14 @@ export namespace Token {
 		export async function send(
 			endpoint: URLConstructor,
 			context: OAuth2Request.Context,
-			options?: { signal?: AbortSignal },
+			options?: { signal?: AbortSignal; expectEmptyResponse?: boolean },
 		) {
 			let request = context.toRequest(endpoint);
 			let response = await fetch(request, { signal: options?.signal });
+			if (options?.expectEmptyResponse) {
+				return;
+			}
+
 			let body = await response.json();
 
 			let result = new OAuth2RequestResult(body);


### PR DESCRIPTION
Twitch OAuth 2.0 returns an empty response on a successful revocation

> If the revocation succeeds, the request returns HTTP status code 200 OK (with no body). [https://dev.twitch.tv/docs/authentication/revoke-tokens/](https://dev.twitch.tv/docs/authentication/revoke-tokens/)

This package always calls `response.json()` on the revocation response. This leads to errors when revoking the token:

```
Error revoking refresh token: SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/undici:4306:19)
    at successSteps (node:internal/deps/undici/undici:4288:27)
    at fullyReadBody (node:internal/deps/undici/undici:2724:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async consumeBody (node:internal/deps/undici/undici:4297:7)
    at Object.send (C:\Users\salzm\Desktop\stream-overlay\node_modules\remix-auth-oauth2\src\lib\token.ts:117:15)
    at OAuth2Strategy.revokeToken (C:\Users\salzm\Desktop\stream-overlay\node_modules\remix-auth-oauth2\src\index.ts:413:3)
    at action (C:\Users\salzm\Desktop\stream-overlay\app\routes\logout._index.tsx:27:8)
```

This PR fixes that by adding a `expectEmptyTokenRevocationResponse` option to make a strategy expect/allow receiving empty token revocations reponses.

The Revocation Specs allow an empty response body so this could not only affect Twitch:
> The content of the response body is ignored by the client as all necessary information is conveyed in the response code. 
[https://datatracker.ietf.org/doc/html/rfc7009#section-2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2)