### PR TITLE
Allow nullable parameters for `ConstructorOptions`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -314,7 +314,7 @@ export namespace OAuth2Strategy {
 		 * This is the Client Secret of your application, provided to you by the
 		 * Identity Provider you're using to authenticate users.
 		 */
-		clientSecret: string;
+		clientSecret: string | null;
 
 		/**
 		 * The endpoint the Identity Provider asks you to send users to log in, or
@@ -330,7 +330,7 @@ export namespace OAuth2Strategy {
 		 * The URL of your application where the Identity Provider will redirect the
 		 * user after they've logged in or authorized your application.
 		 */
-		redirectURI: URLConstructor;
+		redirectURI: URLConstructor | null;
 
 		/**
 		 * The endpoint the Identity Provider uses to revoke an access or refresh


### PR DESCRIPTION
This PR modifies the `ConstructorOptions` class to support nullable values for `clientSecret` and `redirectURI`.

This adjustment is crucial for aligning with the operational logic of the Artic OAuth2 library, where certain configurations may not require these fields. The change primarily affects the `validateAuthorizationCode` method, enhancing its flexibility to handle different authentication scenarios (e.g. `if (this.clientPassword === null) { ...`).