### PR TITLE
Use `new this()` instead of `new OAuth2Strategy()` in the static `discover()` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,7 @@ export class OAuth2Strategy<User> extends Strategy<
 		// Parse the response body
 		let parser = new ObjectParser(await response.json());
 
-		return new OAuth2Strategy(
+		return new this(
 			{
 				authorizationEndpoint: new URL(parser.string("authorization_endpoint")),
 				tokenEndpoint: new URL(parser.string("token_endpoint")),


### PR DESCRIPTION
This solves an issue where strategies that extend `OAuth2Strategy` cannot use the `discover()` method, as it will construct the base class and not the one extending it.

```ts
export class CustomOauthStrategy extends OAuth2Strategy {
	protected authorizationParams(params: URLSearchParams): URLSearchParams {
	  	params.set('custom_param', 'value');
	  	return(params);
	}
}

const strategy = await CustomOauthStrategy.discover(...); // This will be OAuth2Strategy, not CustomOauthStrategy

// Thus, CustomOauthStrategy.authorizationParams will never be called

```