### PR TITLE
chore(README): use warning alert syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A strategy to use and implement OAuth2 framework for authentication with federated services like Google, Facebook, GitHub, etc.
 
-> [!WARN]
+> [!WARNING]
 > This strategy expects the identity provider to strictly follow the OAuth2 specification. If the provider does not follow the specification and diverges from it, this strategy may not work as expected.
 
 ## Supported runtimes


### PR DESCRIPTION
Updates the README formatting to render the warning block based on the alert syntax supported in Github. 

Preview: https://github.com/sean-perkins/remix-auth-oauth2/tree/sp/readme-formatting

You can see the full list of supported types in this Github discussion: https://github.com/orgs/community/discussions/16925