### PR TITLE
Update call of `StateStore.fromRequest()` to use `this.cookieName()`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export class OAuth2Strategy<User> extends Strategy<
 
 		if (!code) throw new ReferenceError("Missing code in the URL");
 
-		let store = StateStore.fromRequest(request);
+		let store = StateStore.fromRequest(request, this.cookieName);
 
 		if (!store.has()) {
 			throw new ReferenceError("Missing state on cookie.");


### PR DESCRIPTION
Introduced in #144 - Using a custom cookie name will break the updates to StateStore, because the cookieName is ignored in the second call to StateStore.fromRequest().

Temporary fix is to use the default cookie name, which is not ideal.


Breaking Line: https://github.com/sergiodxa/remix-auth-oauth2/commit/5743d5f988edbcd9f09bb110e922d44ece6030f3#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L102
