### PR TITLE
Correct import in README for OAuth2 Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm add remix-auth-oauth2
 You can use this strategy by adding it to your authenticator instance and configuring the correct endpoints.
 
 ```ts
-import { OAuthStrategy, CodeChallengeMethod } from "remix-auth-oauth2";
+import { OAuth2Strategy, CodeChallengeMethod } from "remix-auth-oauth2";
 
 export const authenticator = new Authenticator<User>();
 


### PR DESCRIPTION
Hi there! 👋

Thank you for the amazing work on this repo—it’s been super helpful! 

While following the README, I noticed a small typo in the import example for the OAuth2 strategy. The correct import should be:

```tsx
import { OAuth2Strategy } from "remix-auth-oauth2";  
```