### PR TITLE
Move state validation earlier to prevent CSRF and impersonation attacks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,8 +67,22 @@ export class OAuth2Strategy<User> extends Strategy<
 		let url = new URL(request.url);
 
 		let stateUrl = url.searchParams.get("state");
-		let error = url.searchParams.get("error");
 
+		let store = StateStore.fromRequest(request, this.cookieName);
+
+		// If there's a `state` param in the querystring, validate it against the
+		// cookie first to  prevent CSRF attacks.
+		if (stateUrl) {
+			if (!store.has()) {
+				throw new ReferenceError("Missing state on cookie.");
+			}
+
+			if (!store.has(stateUrl)) {
+				throw new RangeError("State in URL doesn't match state in cookie.");
+			}
+		}
+
+		let error = url.searchParams.get("error");
 		if (error) {
 			let description = url.searchParams.get("error_description");
 			let uri = url.searchParams.get("error_uri");
@@ -105,16 +119,6 @@ export class OAuth2Strategy<User> extends Strategy<
 		let code = url.searchParams.get("code");
 
 		if (!code) throw new ReferenceError("Missing code in the URL");
-
-		let store = StateStore.fromRequest(request, this.cookieName);
-
-		if (!store.has()) {
-			throw new ReferenceError("Missing state on cookie.");
-		}
-
-		if (!store.has(stateUrl)) {
-			throw new RangeError("State in URL doesn't match state in cookie.");
-		}
 
 		let codeVerifier = store.get(stateUrl);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,27 +68,6 @@ export class OAuth2Strategy<User> extends Strategy<
 
 		let stateUrl = url.searchParams.get("state");
 
-		let store = StateStore.fromRequest(request, this.cookieName);
-
-		// If there's a `state` param in the querystring, validate it against the
-		// cookie first to  prevent CSRF attacks.
-		if (stateUrl) {
-			if (!store.has()) {
-				throw new ReferenceError("Missing state on cookie.");
-			}
-
-			if (!store.has(stateUrl)) {
-				throw new RangeError("State in URL doesn't match state in cookie.");
-			}
-		}
-
-		let error = url.searchParams.get("error");
-		if (error) {
-			let description = url.searchParams.get("error_description");
-			let uri = url.searchParams.get("error_uri");
-			throw new OAuth2RequestError(error, description, uri, stateUrl);
-		}
-
 		if (!stateUrl) {
 			debug("No state found in the URL, redirecting to authorization endpoint");
 
@@ -114,6 +93,24 @@ export class OAuth2Strategy<User> extends Strategy<
 						.toString(),
 				},
 			});
+		}
+
+		let store = StateStore.fromRequest(request, this.cookieName);
+
+		if (!store.has()) {
+			throw new ReferenceError("Missing state on cookie.");
+		}
+
+		if (!store.has(stateUrl)) {
+			throw new RangeError("State in URL doesn't match state in cookie.");
+		}
+
+		let error = url.searchParams.get("error");
+
+		if (error) {
+			let description = url.searchParams.get("error_description");
+			let uri = url.searchParams.get("error_uri");
+			throw new OAuth2RequestError(error, description, uri, stateUrl);
 		}
 
 		let code = url.searchParams.get("code");


### PR DESCRIPTION
Whenever there's a `state` URL search param, it should be validated before anything else happens. This will help prevent CSRF and impersonation attacks.

For context, at Docker we've had issues in the past where blindly trusting `error` and `error_description` had led to bad actors using our `/auth/error` route to display misleading content to users in attempted phishing attacks. To solve that, we had to validate the `state` param that Auth0 sent back to us against the value stored in Remix's `sessionStorage`.

With the latest version of `remix-auth-oauth2`, there's no more session storage integration, and `state` is managed internally using cookies. So this PR moves the `state` validation of those cookies and the querystring param earlier in the handler so that we can rely on catching a `OAuth2RequestError` in our handler, and any other error means we display a generic error page.
