### PR TITLE
Correct arguments in `authenticator.authenticate()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ First, you will call the `authenticate` method with the provider name you set in
 
 ```ts
 export async function action({ request }: Route.ActionArgs) {
-  await authenticator.authenticate("provider-name", { request });
+  await authenticator.authenticate("provider-name", request);
 }
 ```
 


### PR DESCRIPTION
Small typo in the documentation, instead of passing an object with `request` it should pass the request instance directly. 