### PR TITLE
Add support for additional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ authenticator.use(
 
       scopes: ["openid", "email", "profile"], // optional
       codeChallengeMethod: CodeChallengeMethod.S256, // optional
+      additionalParams: {
+        access_type: "offline",
+        duration: "permanent",
+      }, // optional
     },
     async ({ tokens, request }) => {
       // here you can use the params above to get the user and return it
@@ -97,6 +101,29 @@ let tokens = await strategy.refreshToken(refreshToken);
 ```
 
 The refresh token is part of the `tokens` object the verify function receives. How you store it to call `strategy.refreshToken` and what you do with the `tokens` object after it is up to you.
+
+### Additional Parameters
+
+You can pass additional parameters to the authorization request using the `additionalParams` option. This is useful for provider-specific parameters or custom requirements.
+
+```ts
+let strategy = new OAuth2Strategy(
+  {
+    // ... other options
+    additionalParams: {
+      access_type: "offline",        // Request refresh token
+      prompt: "consent",             // Force consent screen
+      duration: "temporary", // Reddit-like access duration
+    },
+  },
+  verify
+);
+```
+
+Common use cases:
+- **Google OAuth2**: Use `access_type: "offline"` to request refresh tokens
+- **Reddit OAuth2**: Use `duration: "permanent"` to handle token duration
+- **Custom providers**: Add any provider-specific parameters
 
 The most common approach would be to store the refresh token in the user data and then update the session after refreshing the token.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -116,6 +116,30 @@ describe(OAuth2Strategy.name, () => {
 		]);
 	});
 
+	test("redirects with additional parameters if configured", async () => {
+		let strategy = new OAuth2Strategy<User>(
+			{
+				...options,
+				additionalParams: {
+					access_type: "offline",
+					prompt: "consent",
+					include_granted_scopes: "true",
+				},
+			},
+			verify,
+		);
+
+		let request = new Request("https://remix.auth/login");
+
+		let response = await catchResponse(strategy.authenticate(request));
+
+		// biome-ignore lint/style/noNonNullAssertion: This is a test
+		let redirect = new URL(response.headers.get("location")!);
+
+		expect(redirect.searchParams.get("access_type")).toBe("offline");
+		expect(redirect.searchParams.get("duration")).toBe("permanent");
+	});
+
 	test("throws if there's no state in the session", async () => {
 		let strategy = new OAuth2Strategy<User>(options, verify);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,12 @@ export class OAuth2Strategy<User> extends Strategy<
 		params: URLSearchParams,
 		request: Request,
 	): URLSearchParams {
+		if (this.options.additionalParams) {
+			for (let [key, value] of Object.entries(this.options.additionalParams)) {
+				params.append(key, value);
+			}
+		}
+
 		return new URLSearchParams(params);
 	}
 
@@ -365,5 +371,23 @@ export namespace OAuth2Strategy {
 		 * This can be a string or an array of strings.
 		 */
 		audience?: string | string[];
+
+		/**
+		 * Additional parameters to include in the authorization request URL.
+		 * This allows you to pass custom parameters that are specific to your
+		 * OAuth provider or use case.
+		 *
+		 * @example
+		 * ```ts
+		 * {
+		 *   additionalParams: {
+		 *     access_type: "offline",
+		 *     prompt: "consent",
+		 *     include_granted_scopes: "true"
+		 *   }
+		 * }
+		 * ```
+		 */
+		additionalParams?: Record<string, string>;
 	}
 }


### PR DESCRIPTION
Adds support for additionalParams in the OAuth strategy config to pass extra query params to the authorization URL - useful for things like access_type, prompt, or any custom provider-specific options

PS Let me know if I misunderstood something or if there's a better way to handle this